### PR TITLE
Add method to manually switch to next/prev screen

### DIFF
--- a/src/main/java/org/qdwizard/Screen.java
+++ b/src/main/java/org/qdwizard/Screen.java
@@ -43,7 +43,6 @@ public abstract class Screen extends JPanel {
 	/** Data is shared with wizard scope */
 	public Map<Object, Object> data;
 	private Wizard wizard;
-	private String description;
 
 	/**
 	 * Construct a screen.
@@ -214,6 +213,15 @@ public abstract class Screen extends JPanel {
 	public void onFinished() {
 		// does nothing by default
 	}
+	
+	/**
+     * Gets the associated wizard.
+     * 
+     * @param the wizard
+     */
+    public Wizard getWizard() {
+        return this.wizard;
+    }
 
 	/**
 	 * Sets the associated wizard.

--- a/src/main/java/org/qdwizard/Wizard.java
+++ b/src/main/java/org/qdwizard/Wizard.java
@@ -356,9 +356,43 @@ public abstract class Wizard extends WindowAdapter implements ActionListener {
 			dialog.setCursor(new Cursor(Cursor.DEFAULT_CURSOR));
 		}
 	}
+	
+	/**
+	 * Switches to the next screen.
+	 * 
+	 * @return true if successful
+	 */
+	public boolean nextScreen() {
+	    Class<? extends Screen> nextScreen = getNextScreen(current.getClass());
+	    
+	    if(nextScreen == null || !current.canGoNext()) return false;
+	    
+	    if(!current.onNext()) return false;
+	    
+		setScreen(nextScreen);
+		current.onEnter();
+		
+		return true;
+	}
+	
+	/**
+	 * Switches to the previous screen.
+	 * 
+	 * @return true if successful
+	 */
+	public boolean previousScreen() 
+	{
+	    Class<? extends Screen> previousScreen = getPreviousScreen(current.getClass());
+	    
+	    if(previousScreen == null || !current.canGoPrevious()) return false;
+	    
+		setScreen(previousScreen);
+		
+		return true;
+	}
 
 	/**
-	 * Set the screen to display a a class.
+	 * Set the screen to display a class.
 	 * 
 	 * @param screenClass
 	 *            screen class to set. Note that this class must be public or


### PR DESCRIPTION
* Adds the 2 methods
* Adds a wizard getter in Screen class (to make the methods accessible).

Use case: When the installation is finished, automatically go from "Installation Progress" to "Finish" screen.

2 minor fixes:

* Removes unused private description string in Screen
* javadoc spelling